### PR TITLE
Update current time stamp, even for late messages.

### DIFF
--- a/lib/joystick.ex
+++ b/lib/joystick.ex
@@ -86,9 +86,9 @@ defmodule Joystick do
         :ok = poll(res)
         # Logger.debug "Event (#{time}µs): #{inspect event}"
         {:noreply, %{state | last_ts: current_ts}}
-      event ->
+      event = %{timestamp: current_ts} when current_ts < last_ts ->
         Logger.warn "Got late event (#{time}µs): #{inspect event}"
-        {:noreply, state}
+        {:noreply, %{state | last_ts: current_ts}}
     end
   end
 


### PR DESCRIPTION
Thanks for putting this library up!

Not sure if this is the best way to handle this, but for the gamepad I am using, I would always get a "late event" when I started up and then I would get no further events.  The two things I found that fixed it were to either update the time in here, or remove the time guard completely.  I'm still very new to Elixir, so happy to learn if there is a better workaround to this issue.